### PR TITLE
IOTMBL-1522: improve shell handling of device reboots.

### DIFF
--- a/mbl/cli/utils/shell.py
+++ b/mbl/cli/utils/shell.py
@@ -85,7 +85,10 @@ class PosixSSHShell(SSHShell):
                         chan_input = self.chan.recv(MAX_READ_BYTES).decode()
                     except UnicodeDecodeError:
                         continue
-                    if "The system is going down for reboot NOW!" in chan_input:
+                    if (
+                        "The system is going down for reboot NOW!"
+                        in chan_input
+                    ):
                         raise ShellTerminate
                     elif not chan_input:
                         raise ShellTerminate


### PR DESCRIPTION
The interactive shell will now terminate immediately when a reboot is issued on the device.
Previously the shell would hang for 30 seconds until the socket timeout.

**Testing**

Tested manually issuing a reboot and updating the rootfs, which ends in a device reboot.