### PR TITLE
Clarify external dependencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please see the [Contributing][mbl-contributing] document for more information.
 
 [Python > v3.5](https://python.org) and `pip`. 
 
-Linux users require a few other dependencies. Install them using apt-get:
+Linux users require a few other dependencies. Install them using apt-get (this example is for Ubuntu 16.04):
 
 `apt-get install --yes python3-cffi libssl-dev libffi-dev python3-dev`
 


### PR DESCRIPTION
Linux users require some external dependencies. Clarify them in the README.