### PR TITLE
run_cmd writeout function only prints remote stdout

### DIFF
--- a/mbl/cli/actions/pelion_status_action.py
+++ b/mbl/cli/actions/pelion_status_action.py
@@ -34,7 +34,6 @@ def execute(args):
             remote_stdout = output[1]
             if remote_stdout.readable():
                 print(remote_stdout.read().decode())
-                print(output[1].read().decode())
 
 
 class PelionConfigurationError(Exception):


### PR DESCRIPTION
This is to avoid unwanted `stderr` messages appearing when remote commands are executed.

If `check` fails we will print `stderr`. When `check` succeeds we only need to see `stdout` messages in the console.

The specific reason for this change is:
 * When running `get-pelion-status` on an non-provisioned device, unwanted `stderr` messages from the `pelion-provisioning-util` were leaked to the user.