### PR TITLE
Add a "quiet" flag for automation (#32)

### DIFF
--- a/mbl/cli/actions/get_action.py
+++ b/mbl/cli/actions/get_action.py
@@ -14,6 +14,7 @@ def execute(args):
     """Entry point for the get cli command."""
     dev = utils.create_device(args.address)
     print("Getting {} from device: {}\n".format(args.src_path, dev.hostname))
+    ssh.SUPPRESS_PROGRESS = args.quiet
 
     with ssh.SSHSession(dev) as ssh_session:
         ssh_session.get(

--- a/mbl/cli/actions/put_action.py
+++ b/mbl/cli/actions/put_action.py
@@ -15,6 +15,7 @@ def execute(args):
     """Entry point for the put action."""
     dev = utils.create_device(args.address)
     print("Putting {} on device: {}\n".format(args.src_path, dev.hostname))
+    ssh.SUPPRESS_PROGRESS = args.quiet
 
     with ssh.SSHSession(dev) as ssh_session:
         ssh_session.put(

--- a/mbl/cli/actions/shell_action.py
+++ b/mbl/cli/actions/shell_action.py
@@ -18,7 +18,7 @@ def execute(args):
     with ssh.SSHSession(dev) as ssh_session:
         if args.cmd:
             print("Running a command on the device...")
-            ssh_session.run_cmd(args.cmd, check=True, writeout=True)
+            ssh_session.run_cmd(args.cmd, check=True, writeout=not args.quiet)
         else:
             print("Starting an interactive shell...")
             ssh_session.start_shell()

--- a/mbl/cli/args/parser.py
+++ b/mbl/cli/args/parser.py
@@ -37,6 +37,13 @@ def parse_args(description):
     parser.add_argument(
         "-v", "--verbose", help="Enable verbose logging.", action="store_true"
     )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        help="Stop messages from remote commands.",
+        action="store_true",
+    )
+
     command_group = parser.add_subparsers(
         title="mbl-cli supports the following commands",
         description=_load_description_text(),
@@ -96,7 +103,6 @@ def parse_args(description):
     shell.set_defaults(func=shell_action.execute)
 
     save_api_key = command_group.add_parser("save-api-key")
-
     save_api_key.add_argument("key", help="The API key to store.")
     save_api_key.set_defaults(func=save_api_key_action.execute)
 

--- a/mbl/cli/utils/ssh.py
+++ b/mbl/cli/utils/ssh.py
@@ -18,10 +18,12 @@ from . import shell
 
 logging.getLogger("paramiko").setLevel(logging.CRITICAL)
 
+SUPPRESS_PROGRESS = False
+
 
 def scp_progress(filename, size, sent):
     """Display the progress of an scp transfer."""
-    if sent:
+    if sent and not SUPPRESS_PROGRESS:
         try:
             fname = filename.decode()
         except AttributeError:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -60,6 +60,7 @@ class Args:
     dst_path = ""
     recursive = False
     cmd = ""
+    quiet = False
 
 
 class TestListCommand:


### PR DESCRIPTION
Automated test results in LAVA are noisy due to get/put progress reporting and remote command output. So add a -q option to suppress these messages.