### PR TITLE
Add a --version flag (#38)

### DIFF
--- a/mbl/cli/args/parser.py
+++ b/mbl/cli/args/parser.py
@@ -29,6 +29,12 @@ def parse_args(description):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
+        "-V",
+        "--version",
+        help="Show the version and exit.",
+        action="store_true",
+    )
+    parser.add_argument(
         "-a",
         "--address",
         help="The ipv4/6 address or hostname of the device"
@@ -139,7 +145,7 @@ def parse_args(description):
     # We want to fail gracefully, with a consistent
     # help message, in the no argument case.
     # So here's an obligatory hasattr hack.
-    if not hasattr(args_namespace, "func"):
+    if not hasattr(args_namespace, "func") and not args_namespace.version:
         parser.error("No arguments given!")
     else:
         return args_namespace

--- a/mbl/cli/mbl_cli.py
+++ b/mbl/cli/mbl_cli.py
@@ -11,7 +11,7 @@ A toolbox for managing target devices running Mbed Linux OS.
 import enum
 import sys
 import traceback
-
+import pkg_resources
 from mbl.cli.args import parser
 
 
@@ -25,6 +25,9 @@ class ExitCode(enum.Enum):
 def _main():
     try:
         args = parser.parse_args(description=__doc__)
+        if args.version:
+            print(pkg_resources.get_distribution("mbl-cli").version)
+            return ExitCode.SUCCESS.value
         args.func(args)
     except Exception as error:
         if hasattr(error, "return_code"):


### PR DESCRIPTION
Add a --version flag to make it clear which version of MBL CLI users have.