### PR TITLE
IOTMBL-1849 Ensure os.path.sep isn't used to construct remote paths. …

### DIFF
--- a/mbl/cli/actions/provision_action.py
+++ b/mbl/cli/actions/provision_action.py
@@ -100,8 +100,8 @@ def _transfer_certs_to_device(
     ssh.put(local_dev_dir, remote_target_dir, recursive=True)
     ssh.put(local_update_dir, remote_target_dir, recursive=True)
     # move all files to the `target_dir` root for pelion-provisioning-util
-    remote_dev_tmpdir = os.path.join(
-        remote_target_dir, os.path.basename(local_dev_dir)
+    remote_dev_tmpdir = "/".join(
+        [remote_target_dir, os.path.basename(local_dev_dir)]
     )
     ssh.run_cmd(
         "mv {}/* {}".format(
@@ -109,8 +109,8 @@ def _transfer_certs_to_device(
         ),
         check=True,
     )
-    remote_update_tmpdir = os.path.join(
-        remote_target_dir, os.path.basename(local_update_dir)
+    remote_update_tmpdir = "/".join(
+        [remote_target_dir, os.path.basename(local_update_dir)]
     )
     ssh.run_cmd(
         "mv {}/* {}".format(


### PR DESCRIPTION
…(#37)

Provisioning was failing on Windows due to a file path issue.

This commit will:

Ensure we always use a forward slash when constructing remote paths.