### PR TITLE
Mitigate avahi timeout issue. 

### DIFF
--- a/mbl/cli/utils/discovery.py
+++ b/mbl/cli/utils/discovery.py
@@ -150,7 +150,7 @@ def _avahi_browse():
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-    ).communicate()[0]
+    ).communicate(timeout=TIMEOUT)[0]
 
 
 def _parse_avahi_output(raw_output):


### PR DESCRIPTION
Occasionally MBL CLI does not time out after 30 seconds when running the select command.

This commit will:
- Force the avahi process to terminate after the TIMEOUT.