### PR TITLE
Remove 'Pelion Cloud' from help.txt

### DIFF
--- a/mbl/cli/args/help.txt
+++ b/mbl/cli/args/help.txt
@@ -11,6 +11,6 @@ interact directly with your device's shell
   shell               Obtain an interactive shell, or run a single command, on a device.
 
 provision devices for cloud-based device management
-  save-api-key        Save a Pelion Cloud developer API key to persistent storage.
+  save-api-key        Save a Pelion Device Management API key to persistent storage.
   provision-pelion    Provision the selected device with developer and update authority certificates.
   get-pelion-status   Check if the device is correctly configured for Pelion Device Management.


### PR DESCRIPTION
Replace with 'Pelion Device Management'

Pelion Cloud is a misnomer. The service is named Pelion Device Management.