### PR TITLE
Ensure LAVA tests use the latest version of pip (#47)

### DIFF
--- a/ci/lava/dependencies/mbl-install-mbl-cli.yaml
+++ b/ci/lava/dependencies/mbl-install-mbl-cli.yaml
@@ -13,6 +13,9 @@ run:
         # and python3-pip because the lxc-container does not include 
         # these by default.
         - apt-get install -q -q --yes python3-pip python3-cffi libssl-dev libffi-dev python3-dev
+          
+        # Ensure pip version is the latest (8.1.1 doesn't support wheel deployment)
+        - pip3 -qqq install --upgrade pip
 
         # Install the mbl-cli
         - pip3 -qqq install -e .


### PR DESCRIPTION
pip 8.1.1 is the version used in the LAVA LXC containers. However, pip 8.1.1 doesn't support wheel deployment and typically produces errors when some packages are installed. So ensure install-mbl-cli.yaml upgrades pip to the latest version.

The reason we haven't seen a problem is because we're installing mbl-cli in "editable" mode in the LAVA test jobs, so it doesn't actually use pip to build wheels.