### PR TITLE
Pin MBL-CLI dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,22 @@
--i https://pypi.org/simple
--e .
 asn1crypto==0.24.0
-bcrypt==3.1.5
-cffi==1.11.5
+bcrypt==3.1.6
+certifi==2019.3.9
+cffi==1.12.3
+chardet==3.0.4
 cryptography==2.4.2
+future==0.17.1
 idna==2.8
 ifaddr==0.1.6
+mbed-cloud-sdk==2.0.6
+mbl-cli==2.0.0
 paramiko==2.4.2
-pyasn1==0.4.4
+pyasn1==0.4.5
 pycparser==2.19
-pynacl==1.3.0
-pytest
-scp==0.13.0
+PyNaCl==1.3.0
+python-dateutil==2.8.0
+python-dotenv==0.10.1
+requests==2.21.0
+scp==0.13.2
 six==1.12.0
+urllib3==1.24.1
 zeroconf==0.21.3

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,12 @@ def read(file_name):
         return readme.read()
 
 
+def readlines(file_name):
+    """Read a file, return the contents as a list."""
+    with open(file_name, "r") as txt_file:
+        return txt_file.readlines()
+
+
 setup(
     name="mbl-cli",
     version="2.0.0",
@@ -30,13 +36,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
-    install_requires=[
-        "paramiko>=2.4.2",
-        "scp>=0.13.0",
-        "zeroconf>=0.21.3",
-        "mbed-cloud-sdk>=2.0.4",
-        "cryptography==2.4.2",
-    ],
+    install_requires=readlines("requirements.txt"),
     include_package_data=True,
     zip_safe=False,
     entry_points={"console_scripts": ["mbl-cli = mbl.cli.mbl_cli:_main"]},


### PR DESCRIPTION
Avoid upstream disasters by pinning the versions of all dependencies in requirements.txt.
Read the requirements file in setup.py so there is only one list of dependencies to manage.