### PR TITLE
Un-pin pycparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ mbed-cloud-sdk==2.0.6
 mbl-cli==2.0.0
 paramiko==2.4.2
 pyasn1==0.4.5
-pycparser==2.19
 PyNaCl==1.3.0
 python-dateutil==2.8.0
 python-dotenv==0.10.1


### PR DESCRIPTION
In the lxc environment pycparser cannot be changed so the CI cannot
install the mbl-cli.
Tested that in a Python venv and in the lxc environment the cli can be
installed and executed.