### PR TITLE
Requirements: remove MBL CLI from list of dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ future==0.17.1
 idna==2.8
 ifaddr==0.1.6
 mbed-cloud-sdk==2.0.6
-mbl-cli==2.0.0
 paramiko==2.4.2
 pyasn1==0.4.5
 PyNaCl==1.3.0


### PR DESCRIPTION
MBL CLI shouldn't depend on itself as part of the installation. So remove it from the requirements file.