### PR TITLE
Enable SSH timeouts on blocking reads/writes.

### DIFF
--- a/mbl/cli/mbl_cli.py
+++ b/mbl/cli/mbl_cli.py
@@ -41,4 +41,6 @@ def _main():
         return ret_code
     except KeyboardInterrupt:
         print("User quit.", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
     return ExitCode.SUCCESS.value

--- a/mbl/cli/utils/ssh.py
+++ b/mbl/cli/utils/ssh.py
@@ -139,10 +139,10 @@ class SSHSession:
                 for out_fd in ssh_chan_output:
                     while out_fd.readable():
                         buf = out_fd.readline()
-                        if buf:
-                            print(buf, end="")
-                        else:
+                        if not buf:
                             break
+                        print(buf, end="")
+
             if check:
                 _, stdout, stderr = ssh_chan_output
                 exit_status = stdout.channel.recv_exit_status()
@@ -155,7 +155,7 @@ class SSHSession:
                     raise SSHCallError(msg, code=exit_status)
 
         try:
-            cmd_output = self._client.exec_command(cmd)
+            cmd_output = self._client.exec_command(cmd, timeout=60)
         except paramiko.SSHException as ssh_error:
             raise IOError(
                 "The command `{}` failed to execute, "


### PR DESCRIPTION
Occasionally the SSH one shot command doesn't receive an exit code when
the network connection stops. The SSH channel appears to remain open and
blocking reads or writes to the channel will hang indefinitely.

So enable a timeout of 60s on blocking reads and writes when sending single
commands over SSH.

This PR also enables verbose tracebacks when a user issues a Ctrl-C
and refactors the ssh shell code to make it more readable (no functional changes in the shell logic) 

Fixes Jira IOTMBL-2389