### PR TITLE
Don't print shell command help when in quiet mode

### DIFF
--- a/mbl/cli/actions/shell_action.py
+++ b/mbl/cli/actions/shell_action.py
@@ -17,8 +17,10 @@ def execute(args):
 
     with ssh.SSHSession(dev) as ssh_session:
         if args.cmd:
-            print("Running a command on the device...")
+            if not args.quiet:
+                print("Running a command on the device...")
             ssh_session.run_cmd(args.cmd, check=True, writeout=not args.quiet)
         else:
-            print("Starting an interactive shell...")
+            if not args.quiet:
+                print("Starting an interactive shell...")
             ssh_session.start_shell()


### PR DESCRIPTION
When -q is passed on the command line don't print the "Running a command on the device"
and "Starting an interactive shell" messages.