### PR TITLE
ssh: Read ssh config file if it exists in ~/.ssh

### DIFF
--- a/mbl/cli/actions/pelion_status_action.py
+++ b/mbl/cli/actions/pelion_status_action.py
@@ -14,7 +14,7 @@ from . import utils
 
 def execute(args):
     """Entry point for the get-pelion-status command."""
-    device = utils.create_device(args.address)
+    device = utils.create_device(args.address, args.config_hostname)
     with SSHSession(device) as ssh:
         try:
             output = ssh.run_cmd(

--- a/mbl/cli/actions/shell_action.py
+++ b/mbl/cli/actions/shell_action.py
@@ -13,7 +13,7 @@ from . import utils
 
 def execute(args):
     """Entry point for the shell action."""
-    dev = utils.create_device(args.address)
+    dev = utils.create_device(args.address, args.config_hostname)
 
     with ssh.SSHSession(dev) as ssh_session:
         if args.cmd:

--- a/mbl/cli/actions/utils.py
+++ b/mbl/cli/actions/utils.py
@@ -29,13 +29,15 @@ def ssh_session(func):
     # retain metadata from the 'wrapped' function 'object'.
     @functools.wraps(func)
     def wrapper(**kwargs):
-        with ssh.SSHSession(create_device(kwargs["address"])) as session:
+        with ssh.SSHSession(
+            create_device(kwargs["address"], kwargs["hostname"])
+        ) as session:
             func(**kwargs, ssh=session)
 
     return wrapper
 
 
-def create_device(address=None):
+def create_device(address=None, hostname=None):
     """Create a device from either a file or args, depending on args.
 
     :param args Namespace: args from the cli parser.
@@ -47,6 +49,7 @@ def create_device(address=None):
             raise ValueError("Invalid address given.")
     else:
         data = file_handler.read_device_file()
+    data["hostname"] = hostname
     return device.create_device(**data)
 
 

--- a/mbl/cli/args/parser.py
+++ b/mbl/cli/args/parser.py
@@ -43,6 +43,12 @@ def parse_args(description):
         " you want to communicate with. ",
     )
     parser.add_argument(
+        "-c",
+        "--config-hostname",
+        help="The hostname specified in ~/.ssh/config",
+        default="*",
+    )
+    parser.add_argument(
         "-v", "--verbose", help="Enable verbose logging.", action="store_true"
     )
     parser.add_argument(

--- a/mbl/cli/args/parser.py
+++ b/mbl/cli/args/parser.py
@@ -46,7 +46,7 @@ def parse_args(description):
         "-c",
         "--config-hostname",
         help="The hostname specified in ~/.ssh/config",
-        default="*",
+        default="mbl-device",
     )
     parser.add_argument(
         "-v", "--verbose", help="Enable verbose logging.", action="store_true"

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -61,6 +61,7 @@ class Args:
     recursive = False
     cmd = ""
     quiet = False
+    config_hostname = "*"
 
 
 class TestListCommand:
@@ -199,11 +200,14 @@ class TestShellCommand:
 
     def test_ssh_client_is_called_correctly(self, args):
         with mock.patch(
-            "mbl.cli.utils.ssh.SSHClientNoAuth", autospec=True
+            "mbl.cli.utils.ssh.SSHClientWithNoAuthSupport", autospec=True
         ) as client:
             with mock.patch("mbl.cli.utils.ssh.shell") as shell:
                 shell_action.execute(args)
                 client().connect.assert_called_once_with(
-                    args.address, username="root", password=""
+                    args.address,
+                    username="root",
+                    password=None,
+                    key_filename=None,
                 )
                 assert client().invoke_shell.called


### PR DESCRIPTION
Allows connection to production images if a config file contains the
path to the key used to establish trust between ssh server and client.

Also add a command line argument to specify the hostname in the 
config. Defaults to "*".

LAVA: 
https://lava.mbedcloudtesting.com/scheduler/job/66595
https://lava.mbedcloudtesting.com/scheduler/job/66596
https://lava.mbedcloudtesting.com/scheduler/job/66597
https://lava.mbedcloudtesting.com/scheduler/job/66598 