### PR TITLE
ssh: Pass config_hostname to get and put commands.

### DIFF
--- a/mbl/cli/actions/get_action.py
+++ b/mbl/cli/actions/get_action.py
@@ -12,8 +12,8 @@ from . import utils
 
 def execute(args):
     """Entry point for the get cli command."""
-    dev = utils.create_device(args.address)
-    print("Getting {} from device: {}\n".format(args.src_path, dev.hostname))
+    dev = utils.create_device(args.address, args.config_hostname)
+    print("Getting {} from device.\n".format(args.src_path))
     ssh.SUPPRESS_PROGRESS = args.quiet
 
     with ssh.SSHSession(dev) as ssh_session:

--- a/mbl/cli/actions/put_action.py
+++ b/mbl/cli/actions/put_action.py
@@ -13,8 +13,8 @@ from . import utils
 
 def execute(args):
     """Entry point for the put action."""
-    dev = utils.create_device(args.address)
-    print("Putting {} on device: {}\n".format(args.src_path, dev.hostname))
+    dev = utils.create_device(args.address, args.config_hostname)
+    print("Putting {} on device.\n".format(args.src_path))
     ssh.SUPPRESS_PROGRESS = args.quiet
 
     with ssh.SSHSession(dev) as ssh_session:

--- a/tests/integration/test_basic_commands.py
+++ b/tests/integration/test_basic_commands.py
@@ -109,7 +109,7 @@ class TestPutCommand:
 class TestGetCommand:
     def test_getting_a_file_from_device(self, dut_address):
         output = pexpect.spawn(
-            "mbl-cli -a {} get . /var/log/mbl-cloud-client.log".format(
+            "mbl-cli -a {} get /var/log/mbl-cloud-client.log .".format(
                 dut_address
             )
         )
@@ -119,7 +119,7 @@ class TestGetCommand:
 
     def test_getting_a_dir_from_device(self, dut_address):
         mbl_cli = pexpect.spawn(
-            "mbl-cli -a {} get -r . /var/log".format(dut_address)
+            "mbl-cli -a {} get -r /var/log .".format(dut_address)
         )
         mbl_cli.expect(pexpect.EOF)
         mbl_cli.close()


### PR DESCRIPTION
The config hostname wasn't being passed to the get and put commands
which caused them to fail.