### PR TITLE
ssh: Refactor connection logic to allow multiple retries

### DIFF
--- a/mbl/cli/utils/ssh.py
+++ b/mbl/cli/utils/ssh.py
@@ -89,7 +89,7 @@ class SSHSession:
 
     def __enter__(self):
         """Enter the context, connect to the ssh session."""
-        self._connect(num_retries=3, timeout=5)
+        self._connect()
         return self
 
     def __exit__(self, *exception_info):
@@ -156,7 +156,7 @@ class SSHSession:
             _check_print_out(cmd_output, check, writeout)
             return cmd_output
 
-    def _connect(self, num_retries, timeout):
+    def _connect(self):
         config = paramiko.SSHConfig()
         conf_path = pathlib.Path().home() / ".ssh" / "config"
 
@@ -166,22 +166,15 @@ class SSHSession:
         else:
             cdict = None
 
-        for i in range(num_retries):
-            try:
-                self._client.connect(
-                    self.device.address,
-                    username=self.device.username,
-                    password=self.device.password
-                    if self.device.password
-                    else None,
-                    key_filename=cdict["identityfile"] if cdict else None,
-                )
-            except paramiko.SSHException:
-                if i == num_retries:
-                    raise
-                time.sleep(timeout)
-                continue
-            break
+        self._client.connect(
+            self.device.address,
+            username=self.device.username,
+            password=self.device.password
+            if self.device.password
+            else None,
+            key_filename=cdict["identityfile"] if cdict else None,
+            banner_timeout=30
+        )
 
 
 class SCPValidationFailed(Exception):

--- a/mbl/cli/utils/ssh.py
+++ b/mbl/cli/utils/ssh.py
@@ -89,7 +89,7 @@ class SSHSession:
 
     def __enter__(self):
         """Enter the context, connect to the ssh session."""
-        self._connect()
+        self._connect(num_retries=3, timeout=5)
         return self
 
     def __exit__(self, *exception_info):
@@ -156,7 +156,7 @@ class SSHSession:
             _check_print_out(cmd_output, check, writeout)
             return cmd_output
 
-    def _connect(self):
+    def _connect(self, num_retries, timeout):
         config = paramiko.SSHConfig()
         conf_path = pathlib.Path().home() / ".ssh" / "config"
 
@@ -166,25 +166,22 @@ class SSHSession:
         else:
             cdict = None
 
-        try:
-            self._client.connect(
-                self.device.address,
-                username=self.device.username,
-                password=self.device.password
-                if self.device.password
-                else None,
-                key_filename=cdict["identityfile"] if cdict else None,
-            )
-        except paramiko.SSHException:
-            time.sleep(2)
-            self._client.connect(
-                self.device.address,
-                username=self.device.username,
-                password=self.device.password
-                if self.device.password
-                else None,
-                key_filename=cdict["identityfile"] if cdict else None,
-            )
+        for i in range(num_retries):
+            try:
+                self._client.connect(
+                    self.device.address,
+                    username=self.device.username,
+                    password=self.device.password
+                    if self.device.password
+                    else None,
+                    key_filename=cdict["identityfile"] if cdict else None,
+                )
+            except paramiko.SSHException:
+                if i == num_retries:
+                    raise
+                time.sleep(timeout)
+                continue
+            break
 
 
 class SCPValidationFailed(Exception):

--- a/mbl/cli/utils/ssh.py
+++ b/mbl/cli/utils/ssh.py
@@ -169,11 +169,9 @@ class SSHSession:
         self._client.connect(
             self.device.address,
             username=self.device.username,
-            password=self.device.password
-            if self.device.password
-            else None,
+            password=self.device.password if self.device.password else None,
             key_filename=cdict["identityfile"] if cdict else None,
-            banner_timeout=30
+            banner_timeout=30,
         )
 
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -209,5 +209,6 @@ class TestShellCommand:
                     username="root",
                     password=None,
                     key_filename=None,
+                    banner_timeout=30,
                 )
                 assert client().invoke_shell.called


### PR DESCRIPTION
Occasionally the SSH server does not respond to connection attempts,
failing with the message "Failed to read SSH protocol banner".
Retry the connection 3 times with a 5 second delay between each retry.

JIRA: IOTMBL-2660