### PR TITLE
ssh: Retry the ssh connection on failure

### DIFF
--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -209,6 +209,6 @@ class TestShellCommand:
                     username="root",
                     password=None,
                     key_filename=None,
-                    banner_timeout=30,
+                    banner_timeout=60,
                 )
                 assert client().invoke_shell.called


### PR DESCRIPTION
There are often "SSH Protocol Banner" timeouts while waiting for the
server to present us with its SSH protocol banner.
We set paramiko's `banner_timeout` parameter, but that rarely solves
the problem. Therefore we retry the connection `retry_limit` times
to try and decrease the rate of failure.